### PR TITLE
Correctly display @everyone in commands role

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ D'autres script npm sont définis, faites `npm run` pour voir la liste disponibl
 
 # Changelog
 
-## v2.9.0 [WIP]
+## v2.9.0
 
 ### Fixed
 
 -   Toutes les slash commandes étaient en double lorsqu'on invitait Epsibot sur un nouveau serveur...
--   [WIP] `/command list` avait un bug d'affichage sur les roles
+-   `/command list`, `/command add` et `/command edit` avait un bug d'affichage sur le role @everyone si il était spécifié à la main
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "epsibot",
-	"version": "2.8.1",
+	"version": "2.9.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "epsibot",
-			"version": "2.8.1",
+			"version": "2.9.0",
 			"license": "ISC",
 			"dependencies": {
 				"@types/node": "18.14.1",

--- a/src/command/GuildCommand/add.ts
+++ b/src/command/GuildCommand/add.ts
@@ -10,15 +10,19 @@ export enum AddParam {
 
 export async function add(interaction: ChatInputCommandInteraction<"cached">) {
 	const embed = interaction.options.getBoolean(AddParam.embed) ?? false;
-
-	const neededRole =
-		interaction.options.getRole(AddParam.roleNeeded)?.id ?? "";
+	const role = interaction.options.getRole(AddParam.roleNeeded);
 	const autoDelete =
 		interaction.options.getBoolean(AddParam.autoDelete) ?? false;
 
+	let roleNeeded = "";
+	// Saving the role if it's not @everyone
+	if (role && role.id !== interaction.guild.roles.everyone.id) {
+		roleNeeded = role.id;
+	}
+
 	if (embed) {
-		return addEmbed(interaction, neededRole, autoDelete);
+		return addEmbed(interaction, roleNeeded, autoDelete);
 	} else {
-		return addNormal(interaction, neededRole, autoDelete);
+		return addNormal(interaction, roleNeeded, autoDelete);
 	}
 }

--- a/src/command/GuildCommand/edit.ts
+++ b/src/command/GuildCommand/edit.ts
@@ -13,8 +13,7 @@ export enum EditParam {
 }
 export async function edit(interaction: ChatInputCommandInteraction<"cached">) {
 	const name = interaction.options.getString(EditParam.name, true);
-	let roleNeeded =
-		interaction.options.getRole(EditParam.roleNeeded)?.id ?? null;
+	const role = interaction.options.getRole(EditParam.roleNeeded);
 	let autoDelete = interaction.options.getBoolean(EditParam.autoDelete);
 
 	// Get existing command
@@ -32,7 +31,18 @@ export async function edit(interaction: ChatInputCommandInteraction<"cached">) {
 		});
 	}
 
-	if (roleNeeded === null) roleNeeded = command.roleNeeded;
+	// Base case we keep the role of the previous command
+	let roleNeeded = command.roleNeeded;
+	if (role) {
+		if (role.id === interaction.guild.roles.everyone.id) {
+			// If the user specified the @everyone role, we clear the role needed
+			roleNeeded = "";
+		} else {
+			// Last case, we update with what the user gave
+			roleNeeded = role.id;
+		}
+	}
+
 	if (autoDelete === null) autoDelete = command.autoDelete;
 
 	if (command instanceof CustomCommand)


### PR DESCRIPTION
Si l'user passe le rôle `@everyone`, le bot reçoit un id de role qui est spécifique au serveur.
En soit pas de problème, mais quand on essaie d'afficher le rôle avec `<@&id>`, on obtient un truc bizarre qui ressemble à `@@everyone` et c'est moche
Si on le fait à la main, on a le même résultat, et le message ne ping personne

Vu que ce qui nous intéresse c'est si il faut un rôle spécial pour lancer une commande, `@everyone` est le cas de base, on préfère save un string vide qu'un id spécifique, ça permet de plus tard pouvoir faire des query sur toutes les commandes dispo pour tout le monde

Du coup on fait rien de spécial à l'affichage, on s'assure juste que si le role que l'user a envoyé correspond à `@everyone`, on save un string vide